### PR TITLE
Adjust `Algebra.Linear` imports for GHC 9.6.3

### DIFF
--- a/Algebra/Linear.hs
+++ b/Algebra/Linear.hs
@@ -30,7 +30,7 @@ module Algebra.Linear where
 
 import Algebra.Classes
 import Algebra.Category.Laws (laws_bicartesian,testableCat)
-import Prelude (Show(..),Eq(..),($),Ord,error,flip,IO,Bool,Int)
+import Prelude (Show(..),Eq(..),($),Ord,Functor(..),Monad(..),error,flip,IO,Bool,Int)
 import Control.Applicative
 import Data.Foldable hiding (sum,product)
 import Data.Traversable


### PR DESCRIPTION
When building Gasp with GHC 9.6.3 / base 4.18.1.0,  `Algebra.Linear`  cannot be compiled because the functor and monad type classes appear to be out of scope. This patch expands the imports to fix this issue.

I was able to compile the patched version with the following:
* GHC 9.6.3 / base 4.18.1.0
* GHC 9.4.8 / base 4.17.2.1
* GHC 9.2.8 / base 4.16.4.0
* GHC 9.0.2 / base 4.15.1.0